### PR TITLE
fix(auto-compact): add required name parameter to registerHook call

### DIFF
--- a/extensions/auto-compact/index.ts
+++ b/extensions/auto-compact/index.ts
@@ -35,13 +35,20 @@ export default function register(api: OpenClawPluginApi) {
   // Hook into message:preprocessed to clear tool outputs BEFORE sending to LLM
   // This is the key difference from wrong implementation - we don't write sessions,
   // we just mutate messages in-flight
-  api.registerHook("message:preprocessed", async (event) => {
-    try {
-      await handleMessagePreprocessed(event, api);
-    } catch (err) {
-      log.error("Micro-compaction failed in message:preprocessed hook", err);
-    }
-  });
+  api.registerHook(
+    "message:preprocessed",
+    async (event) => {
+      try {
+        await handleMessagePreprocessed(event, api);
+      } catch (err) {
+        log.error("Micro-compaction failed in message:preprocessed hook", err);
+      }
+    },
+    {
+      name: "micro-compaction",
+      description: "Clear verbose tool outputs when approaching token limit",
+    },
+  );
 
   log.info("Micro-Compaction hook registered (message:preprocessed)");
 }


### PR DESCRIPTION
## Problem
Plugin was failing to register its hook silently. Gateway logs showed:
```
[gateway] [plugins] hook registration missing name (plugin=auto-compact)
```

This prevented the `message:preprocessed` hook from firing, so micro-compaction never triggered even when enabled at 80% threshold.

## Root Cause
`OpenClawPluginHookOptions` requires a `name` field, but the plugin wasn't providing it:

```typescript
// Before (broken)
api.registerHook("message:preprocessed", async (event) => { ... });

// After (fixed)
api.registerHook("message:preprocessed", async (event) => { ... }, {
  name: "micro-compaction",
  description: "Clear verbose tool outputs when approaching token limit",
});
```

## Testing
- ✅ Plugin loads successfully (no registration warnings)
- ✅ Hook registered (confirmed in gateway logs)
- ✅ Build passes

## References
- Triage: `workspace-admin/memory/2026-04-02-microcompact-triage.md`
- Original implementation: PR #5